### PR TITLE
Add --normalize flag for clean config comparisons

### DIFF
--- a/eslint-config-old.json
+++ b/eslint-config-old.json
@@ -31,127 +31,51 @@
     "@typescript-eslint"
   ],
   "rules": {
-    "semi": [
-      2,
-      "always"
-    ],
-    "no-extra-semi": [
-      2
-    ],
-    "no-tabs": [
-      0
-    ],
-    "react/jsx-indent": [
-      2,
-      "tab"
-    ],
-    "react/jsx-indent-props": [
-      2,
-      "tab"
-    ],
-    "indent": [
-      2,
-      "tab",
-      {
-        "SwitchCase": 1,
-        "flatTernaryExpressions": false,
-        "offsetTernaryExpressions": false,
-        "ignoreComments": false
-      }
-    ],
-    "brace-style": [
-      2,
-      "stroustrup",
-      {
-        "allowSingleLine": false
-      }
-    ],
-    "react/jsx-filename-extension": [
-      1,
-      {
-        "allow": "as-needed"
-      }
-    ],
-    "react/prop-types": [
-      0,
-      {
-        "ignore": [],
-        "customValidators": [],
-        "skipUndeclared": false
-      }
-    ],
-    "jsx-a11y/label-has-associated-control": [
-      2,
-      {
-        "labelComponents": [],
-        "labelAttributes": [],
-        "controlComponents": [],
-        "assert": "both",
-        "depth": 25
-      }
-    ],
-    "react/jsx-one-expression-per-line": [
-      0,
-      {
-        "allow": "single-child"
-      }
-    ],
-    "no-console": [
-      2
-    ],
-    "max-len": [
-      2,
-      {
-        "code": 120,
-        "ignoreTrailingComments": true,
-        "ignoreComments": true,
-        "ignoreUrls": true,
-        "ignoreStrings": true,
-        "tabWidth": 1
-      }
-    ],
-    "linebreak-style": [
-      2,
-      "windows"
-    ],
-    "react/function-component-definition": [
-      2,
-      {
-        "namedComponents": "arrow-function",
-        "unnamedComponents": "arrow-function"
-      }
-    ],
-    "react/jsx-no-useless-fragment": [
-      2
-    ],
-    "no-plusplus": [
+    "@typescript-eslint/adjacent-overload-signatures": "error",
+    "@typescript-eslint/array-type": "error",
+    "@typescript-eslint/ban-ts-comment": [
       "error",
       {
-        "allowForLoopAfterthoughts": true
+        "minimumDescriptionLength": 10
       }
     ],
-    "comma-dangle": [
-      2,
-      "only-multiline"
-    ],
-    "space-before-function-paren": [
-      2,
-      "never"
-    ],
-    "multiline-ternary": [
-      2,
-      "never"
-    ],
-    "compat/compat": [
-      "error"
-    ],
-    "no-var": [
-      "warn"
-    ],
-    "object-shorthand": [
-      "warn",
-      "properties"
-    ],
+    "@typescript-eslint/ban-tslint-comment": "error",
+    "@typescript-eslint/ban-types": "error",
+    "@typescript-eslint/class-literal-property-style": "error",
+    "@typescript-eslint/consistent-generic-constructors": "error",
+    "@typescript-eslint/consistent-indexed-object-style": "error",
+    "@typescript-eslint/consistent-type-assertions": "error",
+    "@typescript-eslint/consistent-type-definitions": "error",
+    "@typescript-eslint/no-array-constructor": "error",
+    "@typescript-eslint/no-confusing-non-null-assertion": "error",
+    "@typescript-eslint/no-duplicate-enum-values": "error",
+    "@typescript-eslint/no-dynamic-delete": "error",
+    "@typescript-eslint/no-empty-function": "error",
+    "@typescript-eslint/no-empty-interface": "error",
+    "@typescript-eslint/no-explicit-any": "error",
+    "@typescript-eslint/no-extra-non-null-assertion": "error",
+    "@typescript-eslint/no-extraneous-class": "error",
+    "@typescript-eslint/no-inferrable-types": "error",
+    "@typescript-eslint/no-invalid-void-type": "error",
+    "@typescript-eslint/no-loss-of-precision": "error",
+    "@typescript-eslint/no-misused-new": "error",
+    "@typescript-eslint/no-namespace": "error",
+    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": "error",
+    "@typescript-eslint/no-non-null-asserted-optional-chain": "error",
+    "@typescript-eslint/no-non-null-assertion": "error",
+    "@typescript-eslint/no-this-alias": "error",
+    "@typescript-eslint/no-unnecessary-type-constraint": "error",
+    "@typescript-eslint/no-unsafe-declaration-merging": "error",
+    "@typescript-eslint/no-unused-vars": "error",
+    "@typescript-eslint/no-useless-constructor": "error",
+    "@typescript-eslint/no-var-requires": "error",
+    "@typescript-eslint/prefer-as-const": "error",
+    "@typescript-eslint/prefer-for-of": "error",
+    "@typescript-eslint/prefer-function-type": "error",
+    "@typescript-eslint/prefer-literal-enum-member": "error",
+    "@typescript-eslint/prefer-namespace-keyword": "error",
+    "@typescript-eslint/triple-slash-reference": "error",
+    "@typescript-eslint/unified-signatures": "error",
     "accessor-pairs": [
       "error",
       {
@@ -172,6 +96,17 @@
         "allowVoid": false
       }
     ],
+    "arrow-body-style": [
+      "error",
+      "as-needed",
+      {
+        "requireReturnForObjectLiteral": false
+      }
+    ],
+    "arrow-parens": [
+      "error",
+      "always"
+    ],
     "arrow-spacing": [
       "error",
       {
@@ -179,9 +114,17 @@
         "after": true
       }
     ],
+    "block-scoped-var": "error",
     "block-spacing": [
       "error",
       "always"
+    ],
+    "brace-style": [
+      "error",
+      "stroustrup",
+      {
+        "allowSingleLine": false
+      }
     ],
     "camelcase": [
       "error",
@@ -195,6 +138,34 @@
         "ignoreImports": false
       }
     ],
+    "class-methods-use-this": [
+      "error",
+      {
+        "exceptMethods": [
+          "render",
+          "getInitialState",
+          "getDefaultProps",
+          "getChildContext",
+          "componentWillMount",
+          "UNSAFE_componentWillMount",
+          "componentDidMount",
+          "componentWillReceiveProps",
+          "UNSAFE_componentWillReceiveProps",
+          "shouldComponentUpdate",
+          "componentWillUpdate",
+          "UNSAFE_componentWillUpdate",
+          "componentDidUpdate",
+          "componentWillUnmount",
+          "componentDidCatch",
+          "getSnapshotBeforeUpdate"
+        ],
+        "enforceForClassFields": true
+      }
+    ],
+    "comma-dangle": [
+      "error",
+      "only-multiline"
+    ],
     "comma-spacing": [
       "error",
       {
@@ -206,6 +177,7 @@
       "error",
       "last"
     ],
+    "compat/compat": "error",
     "computed-property-spacing": [
       "error",
       "never",
@@ -213,16 +185,20 @@
         "enforceForClassMembers": true
       }
     ],
-    "constructor-super": [
-      "error"
-    ],
+    "consistent-return": "error",
+    "constructor-super": "error",
     "curly": [
       "error",
       "multi-line"
     ],
-    "default-case-last": [
-      "error"
+    "default-case": [
+      "error",
+      {
+        "commentPattern": "^no default$"
+      }
     ],
+    "default-case-last": "error",
+    "default-param-last": "error",
     "dot-location": [
       "error",
       "property"
@@ -245,9 +221,19 @@
         "null": "ignore"
       }
     ],
+    "for-direction": "error",
     "func-call-spacing": [
       "error",
       "never"
+    ],
+    "func-names": "warn",
+    "function-call-argument-newline": [
+      "error",
+      "consistent"
+    ],
+    "function-paren-newline": [
+      "error",
+      "multiline-arguments"
     ],
     "generator-star-spacing": [
       "error",
@@ -256,568 +242,32 @@
         "after": true
       }
     ],
-    "key-spacing": [
+    "getter-return": [
       "error",
       {
-        "beforeColon": false,
-        "afterColon": true
+        "allowImplicit": true
       }
     ],
-    "keyword-spacing": [
+    "global-require": "error",
+    "grouped-accessor-pairs": "error",
+    "guard-for-in": "error",
+    "implicit-arrow-linebreak": [
       "error",
+      "beside"
+    ],
+    "import/export": "error",
+    "import/extensions": [
+      "error",
+      "ignorePackages",
       {
-        "before": true,
-        "after": true
+        "js": "never",
+        "mjs": "never",
+        "jsx": "never"
       }
     ],
-    "lines-between-class-members": [
-      "error",
-      "always",
-      {
-        "exceptAfterSingleLine": true
-      }
-    ],
-    "new-cap": [
-      "error",
-      {
-        "newIsCap": true,
-        "capIsNew": false,
-        "properties": true
-      }
-    ],
-    "new-parens": [
-      "error"
-    ],
-    "no-array-constructor": [
-      "error"
-    ],
-    "no-async-promise-executor": [
-      "error"
-    ],
-    "no-caller": [
-      "error"
-    ],
-    "no-case-declarations": [
-      "error"
-    ],
-    "no-class-assign": [
-      "error"
-    ],
-    "no-compare-neg-zero": [
-      "error"
-    ],
-    "no-cond-assign": [
-      "error",
-      "always"
-    ],
-    "no-const-assign": [
-      "error"
-    ],
-    "no-constant-condition": [
-      "error",
-      {
-        "checkLoops": false
-      }
-    ],
-    "no-control-regex": [
-      "error"
-    ],
-    "no-debugger": [
-      "error"
-    ],
-    "no-delete-var": [
-      "error"
-    ],
-    "no-dupe-args": [
-      "error"
-    ],
-    "no-dupe-class-members": [
-      "error"
-    ],
-    "no-dupe-keys": [
-      "error"
-    ],
-    "no-duplicate-case": [
-      "error"
-    ],
-    "no-useless-backreference": [
-      "error"
-    ],
-    "no-empty": [
-      "error",
-      {
-        "allowEmptyCatch": true
-      }
-    ],
-    "no-empty-character-class": [
-      "error"
-    ],
-    "no-empty-pattern": [
-      "error"
-    ],
-    "no-eval": [
-      "error"
-    ],
-    "no-ex-assign": [
-      "error"
-    ],
-    "no-extend-native": [
-      "error"
-    ],
-    "no-extra-bind": [
-      "error"
-    ],
-    "no-extra-boolean-cast": [
-      "error"
-    ],
-    "no-extra-parens": [
-      "error",
-      "functions"
-    ],
-    "no-fallthrough": [
-      "error"
-    ],
-    "no-floating-decimal": [
-      "error"
-    ],
-    "no-func-assign": [
-      "error"
-    ],
-    "no-global-assign": [
-      "error",
-      {
-        "exceptions": []
-      }
-    ],
-    "no-implied-eval": [
-      "error"
-    ],
-    "no-import-assign": [
-      "error"
-    ],
-    "no-invalid-regexp": [
-      "error"
-    ],
-    "no-irregular-whitespace": [
-      "error"
-    ],
-    "no-iterator": [
-      "error"
-    ],
-    "no-labels": [
-      "error",
-      {
-        "allowLoop": false,
-        "allowSwitch": false
-      }
-    ],
-    "no-lone-blocks": [
-      "error"
-    ],
-    "no-loss-of-precision": [
-      "error"
-    ],
-    "no-misleading-character-class": [
-      "error"
-    ],
-    "no-prototype-builtins": [
-      "error"
-    ],
-    "no-useless-catch": [
-      "error"
-    ],
-    "no-mixed-operators": [
-      "error",
-      {
-        "groups": [
-          [
-            "==",
-            "!=",
-            "===",
-            "!==",
-            ">",
-            ">=",
-            "<",
-            "<="
-          ],
-          [
-            "&&",
-            "||"
-          ],
-          [
-            "in",
-            "instanceof"
-          ]
-        ],
-        "allowSamePrecedence": true
-      }
-    ],
-    "no-mixed-spaces-and-tabs": [
-      "error"
-    ],
-    "no-multi-spaces": [
-      "error",
-      {
-        "ignoreEOLComments": false
-      }
-    ],
-    "no-multi-str": [
-      "error"
-    ],
-    "no-multiple-empty-lines": [
-      "error",
-      {
-        "max": 1,
-        "maxBOF": 0,
-        "maxEOF": 0
-      }
-    ],
-    "no-new": [
-      "error"
-    ],
-    "no-new-func": [
-      "error"
-    ],
-    "no-new-object": [
-      "error"
-    ],
-    "no-new-symbol": [
-      "error"
-    ],
-    "no-new-wrappers": [
-      "error"
-    ],
-    "no-obj-calls": [
-      "error"
-    ],
-    "no-octal": [
-      "error"
-    ],
-    "no-octal-escape": [
-      "error"
-    ],
-    "no-proto": [
-      "error"
-    ],
-    "no-redeclare": [
-      "error",
-      {
-        "builtinGlobals": false
-      }
-    ],
-    "no-regex-spaces": [
-      "error"
-    ],
-    "no-return-assign": [
-      "error",
-      "except-parens"
-    ],
-    "no-self-assign": [
-      "error",
-      {
-        "props": true
-      }
-    ],
-    "no-self-compare": [
-      "error"
-    ],
-    "no-sequences": [
-      "error"
-    ],
-    "no-shadow-restricted-names": [
-      "error"
-    ],
-    "no-sparse-arrays": [
-      "error"
-    ],
-    "no-template-curly-in-string": [
-      "error"
-    ],
-    "no-this-before-super": [
-      "error"
-    ],
-    "no-throw-literal": [
-      "error"
-    ],
-    "no-trailing-spaces": [
-      "error",
-      {
-        "skipBlankLines": false,
-        "ignoreComments": false
-      }
-    ],
-    "no-undef": [
-      "error"
-    ],
-    "no-undef-init": [
-      "error"
-    ],
-    "no-unexpected-multiline": [
-      "error"
-    ],
-    "no-unmodified-loop-condition": [
-      "error"
-    ],
-    "no-unneeded-ternary": [
-      "error",
-      {
-        "defaultAssignment": false
-      }
-    ],
-    "no-unreachable": [
-      "error"
-    ],
-    "no-unreachable-loop": [
-      "error",
-      {
-        "ignore": []
-      }
-    ],
-    "no-unsafe-finally": [
-      "error"
-    ],
-    "no-unsafe-negation": [
-      "error"
-    ],
-    "no-unused-expressions": [
-      "error",
-      {
-        "allowShortCircuit": true,
-        "allowTernary": true,
-        "allowTaggedTemplates": true,
-        "enforceForJSX": false
-      }
-    ],
-    "no-unused-vars": [
-      "error",
-      {
-        "args": "none",
-        "caughtErrors": "none",
-        "ignoreRestSiblings": true,
-        "vars": "all"
-      }
-    ],
-    "no-use-before-define": [
-      "error",
-      {
-        "functions": false,
-        "classes": false,
-        "variables": false
-      }
-    ],
-    "no-useless-call": [
-      "error"
-    ],
-    "no-useless-computed-key": [
-      "error"
-    ],
-    "no-useless-constructor": [
-      "error"
-    ],
-    "no-useless-escape": [
-      "error"
-    ],
-    "no-useless-rename": [
-      "error",
-      {
-        "ignoreDestructuring": false,
-        "ignoreImport": false,
-        "ignoreExport": false
-      }
-    ],
-    "no-useless-return": [
-      "error"
-    ],
-    "no-void": [
-      "error"
-    ],
-    "no-whitespace-before-property": [
-      "error"
-    ],
-    "no-with": [
-      "error"
-    ],
-    "object-curly-newline": [
-      "error",
-      {
-        "multiline": true,
-        "consistent": true
-      }
-    ],
-    "object-curly-spacing": [
-      "error",
-      "always"
-    ],
-    "object-property-newline": [
-      "error",
-      {
-        "allowMultiplePropertiesPerLine": true,
-        "allowAllPropertiesOnSameLine": false
-      }
-    ],
-    "one-var": [
-      "error",
-      {
-        "initialized": "never"
-      }
-    ],
-    "operator-linebreak": [
-      "error",
-      "after",
-      {
-        "overrides": {
-          "?": "before",
-          ":": "before",
-          "|>": "before"
-        }
-      }
-    ],
-    "padded-blocks": [
-      "error",
-      {
-        "blocks": "never",
-        "switches": "never",
-        "classes": "never"
-      }
-    ],
-    "prefer-const": [
-      "error",
-      {
-        "destructuring": "all",
-        "ignoreReadBeforeAssign": false
-      }
-    ],
-    "prefer-promise-reject-errors": [
-      "error",
-      {
-        "allowEmptyReject": true
-      }
-    ],
-    "prefer-regex-literals": [
-      "error",
-      {
-        "disallowRedundantWrapping": true
-      }
-    ],
-    "quote-props": [
-      "error",
-      "as-needed"
-    ],
-    "quotes": [
-      "error",
-      "single",
-      {
-        "avoidEscape": true,
-        "allowTemplateLiterals": false
-      }
-    ],
-    "rest-spread-spacing": [
-      "error",
-      "never"
-    ],
-    "semi-spacing": [
-      "error",
-      {
-        "before": false,
-        "after": true
-      }
-    ],
-    "space-before-blocks": [
-      "error",
-      "always"
-    ],
-    "space-in-parens": [
-      "error",
-      "never"
-    ],
-    "space-infix-ops": [
-      "error"
-    ],
-    "space-unary-ops": [
-      "error",
-      {
-        "words": true,
-        "nonwords": false
-      }
-    ],
-    "spaced-comment": [
-      "error",
-      "always",
-      {
-        "line": {
-          "markers": [
-            "*package",
-            "!",
-            "/",
-            ",",
-            "="
-          ]
-        },
-        "block": {
-          "balanced": true,
-          "markers": [
-            "*package",
-            "!",
-            ",",
-            ":",
-            "::",
-            "flow-include"
-          ],
-          "exceptions": [
-            "*"
-          ]
-        }
-      }
-    ],
-    "symbol-description": [
-      "error"
-    ],
-    "template-curly-spacing": [
-      "error",
-      "never"
-    ],
-    "template-tag-spacing": [
-      "error",
-      "never"
-    ],
-    "unicode-bom": [
-      "error",
-      "never"
-    ],
-    "use-isnan": [
-      "error",
-      {
-        "enforceForSwitchCase": true,
-        "enforceForIndexOf": true
-      }
-    ],
-    "valid-typeof": [
-      "error",
-      {
-        "requireStringLiterals": true
-      }
-    ],
-    "wrap-iife": [
-      "error",
-      "any",
-      {
-        "functionPrototypeMethods": true
-      }
-    ],
-    "yield-star-spacing": [
-      "error",
-      "both"
-    ],
-    "yoda": [
-      "error",
-      "never"
-    ],
-    "import/export": [
-      "error"
-    ],
-    "import/first": [
-      "error"
-    ],
+    "import/first": "error",
+    "import/named": "error",
+    "import/newline-after-import": "error",
     "import/no-absolute-path": [
       "error",
       {
@@ -826,214 +276,98 @@
         "amd": false
       }
     ],
-    "import/no-duplicates": [
-      "error"
-    ],
-    "import/no-named-default": [
-      "error"
-    ],
-    "import/no-webpack-loader-syntax": [
-      "error"
-    ],
-    "n/handle-callback-err": [
-      "error",
-      "^(err|error)$"
-    ],
-    "n/no-callback-literal": [
-      "error"
-    ],
-    "n/no-deprecated-api": [
-      "error"
-    ],
-    "n/no-exports-assign": [
-      "error"
-    ],
-    "n/no-new-require": [
-      "error"
-    ],
-    "n/no-path-concat": [
-      "error"
-    ],
-    "n/process-exit-as-throw": [
-      "error"
-    ],
-    "promise/param-names": [
-      "error"
-    ],
-    "@typescript-eslint/adjacent-overload-signatures": [
-      "error"
-    ],
-    "@typescript-eslint/array-type": [
-      "error"
-    ],
-    "@typescript-eslint/ban-tslint-comment": [
-      "error"
-    ],
-    "@typescript-eslint/class-literal-property-style": [
-      "error"
-    ],
-    "@typescript-eslint/consistent-generic-constructors": [
-      "error"
-    ],
-    "@typescript-eslint/consistent-indexed-object-style": [
-      "error"
-    ],
-    "@typescript-eslint/consistent-type-assertions": [
-      "error"
-    ],
-    "@typescript-eslint/consistent-type-definitions": [
-      "error"
-    ],
-    "@typescript-eslint/no-confusing-non-null-assertion": [
-      "error"
-    ],
-    "no-empty-function": [
-      "off",
-      {
-        "allow": [
-          "arrowFunctions",
-          "functions",
-          "methods"
-        ]
-      }
-    ],
-    "@typescript-eslint/no-empty-function": [
-      "error"
-    ],
-    "@typescript-eslint/no-empty-interface": [
-      "error"
-    ],
-    "@typescript-eslint/no-inferrable-types": [
-      "error"
-    ],
-    "@typescript-eslint/prefer-for-of": [
-      "error"
-    ],
-    "@typescript-eslint/prefer-function-type": [
-      "error"
-    ],
-    "@typescript-eslint/prefer-namespace-keyword": [
-      "error"
-    ],
-    "@typescript-eslint/ban-ts-comment": [
+    "import/no-amd": "error",
+    "import/no-cycle": [
       "error",
       {
-        "minimumDescriptionLength": 10
+        "maxDepth": "∞",
+        "ignoreExternal": false,
+        "allowUnsafeDynamicCyclicDependency": false
       }
     ],
-    "@typescript-eslint/ban-types": [
-      "error"
-    ],
-    "@typescript-eslint/no-array-constructor": [
-      "error"
-    ],
-    "@typescript-eslint/no-duplicate-enum-values": [
-      "error"
-    ],
-    "@typescript-eslint/no-dynamic-delete": [
-      "error"
-    ],
-    "@typescript-eslint/no-explicit-any": [
-      "error"
-    ],
-    "@typescript-eslint/no-extra-non-null-assertion": [
-      "error"
-    ],
-    "@typescript-eslint/no-extraneous-class": [
-      "error"
-    ],
-    "@typescript-eslint/no-invalid-void-type": [
-      "error"
-    ],
-    "@typescript-eslint/no-loss-of-precision": [
-      "error"
-    ],
-    "@typescript-eslint/no-misused-new": [
-      "error"
-    ],
-    "@typescript-eslint/no-namespace": [
-      "error"
-    ],
-    "@typescript-eslint/no-non-null-asserted-nullish-coalescing": [
-      "error"
-    ],
-    "@typescript-eslint/no-non-null-asserted-optional-chain": [
-      "error"
-    ],
-    "@typescript-eslint/no-non-null-assertion": [
-      "error"
-    ],
-    "@typescript-eslint/no-this-alias": [
-      "error"
-    ],
-    "@typescript-eslint/no-unnecessary-type-constraint": [
-      "error"
-    ],
-    "@typescript-eslint/no-unsafe-declaration-merging": [
-      "error"
-    ],
-    "@typescript-eslint/no-unused-vars": [
-      "error"
-    ],
-    "@typescript-eslint/no-useless-constructor": [
-      "error"
-    ],
-    "@typescript-eslint/no-var-requires": [
-      "error"
-    ],
-    "@typescript-eslint/prefer-as-const": [
-      "error"
-    ],
-    "@typescript-eslint/prefer-literal-enum-member": [
-      "error"
-    ],
-    "@typescript-eslint/triple-slash-reference": [
-      "error"
-    ],
-    "@typescript-eslint/unified-signatures": [
-      "error"
-    ],
-    "for-direction": [
-      "error"
-    ],
-    "getter-return": [
+    "import/no-duplicates": "error",
+    "import/no-dynamic-require": "error",
+    "import/no-extraneous-dependencies": [
       "error",
       {
-        "allowImplicit": true
+        "devDependencies": [
+          "test/**",
+          "tests/**",
+          "spec/**",
+          "**/__tests__/**",
+          "**/__mocks__/**",
+          "test.{js,jsx}",
+          "test-*.{js,jsx}",
+          "**/*{.,_}{test,spec}.{js,jsx}",
+          "**/jest.config.js",
+          "**/jest.setup.js",
+          "**/vue.config.js",
+          "**/webpack.config.js",
+          "**/webpack.config.*.js",
+          "**/rollup.config.js",
+          "**/rollup.config.*.js",
+          "**/gulpfile.js",
+          "**/gulpfile.*.js",
+          "**/Gruntfile{,.js}",
+          "**/protractor.conf.js",
+          "**/protractor.conf.*.js",
+          "**/karma.conf.js",
+          "**/.eslintrc.js"
+        ],
+        "optionalDependencies": false
       }
     ],
-    "no-dupe-else-if": [
-      "error"
-    ],
-    "no-inner-declarations": [
-      "error"
-    ],
-    "no-nonoctal-decimal-escape": [
-      "error"
-    ],
-    "no-setter-return": [
-      "error"
-    ],
-    "no-unsafe-optional-chaining": [
+    "import/no-import-module-exports": [
       "error",
       {
-        "disallowArithmeticOperators": true
+        "exceptions": []
       }
     ],
-    "no-unused-labels": [
-      "error"
+    "import/no-mutable-exports": "error",
+    "import/no-named-as-default": "error",
+    "import/no-named-as-default-member": "error",
+    "import/no-named-default": "error",
+    "import/no-relative-packages": "error",
+    "import/no-self-import": "error",
+    "import/no-unresolved": [
+      "error",
+      {
+        "commonjs": true,
+        "caseSensitive": true,
+        "caseSensitiveStrict": false
+      }
     ],
-    "require-yield": [
-      "error"
+    "import/no-useless-path-segments": [
+      "error",
+      {
+        "commonjs": true
+      }
     ],
-    "react-hooks/rules-of-hooks": [
-      "error"
+    "import/no-webpack-loader-syntax": "error",
+    "import/order": [
+      "error",
+      {
+        "groups": [
+          [
+            "builtin",
+            "external",
+            "internal"
+          ]
+        ],
+        "distinctGroup": true,
+        "warnOnUnassignedImports": false
+      }
     ],
-    "react-hooks/exhaustive-deps": [
-      "error"
-    ],
-    "jsx-a11y/accessible-emoji": [
-      "off"
+    "import/prefer-default-export": "error",
+    "indent": [
+      "error",
+      "tab",
+      {
+        "SwitchCase": 1,
+        "flatTernaryExpressions": false,
+        "offsetTernaryExpressions": false,
+        "ignoreComments": false
+      }
     ],
     "jsx-a11y/alt-text": [
       "error",
@@ -1072,33 +406,17 @@
         ]
       }
     ],
-    "jsx-a11y/aria-activedescendant-has-tabindex": [
-      "error"
-    ],
-    "jsx-a11y/aria-props": [
-      "error"
-    ],
-    "jsx-a11y/aria-proptypes": [
-      "error"
-    ],
+    "jsx-a11y/aria-activedescendant-has-tabindex": "error",
+    "jsx-a11y/aria-props": "error",
+    "jsx-a11y/aria-proptypes": "error",
     "jsx-a11y/aria-role": [
       "error",
       {
         "ignoreNonDOM": false
       }
     ],
-    "jsx-a11y/aria-unsupported-elements": [
-      "error"
-    ],
-    "jsx-a11y/autocomplete-valid": [
-      "off",
-      {
-        "inputComponents": []
-      }
-    ],
-    "jsx-a11y/click-events-have-key-events": [
-      "error"
-    ],
+    "jsx-a11y/aria-unsupported-elements": "error",
+    "jsx-a11y/click-events-have-key-events": "error",
     "jsx-a11y/control-has-associated-label": [
       "error",
       {
@@ -1138,21 +456,21 @@
         ]
       }
     ],
-    "jsx-a11y/html-has-lang": [
-      "error"
+    "jsx-a11y/html-has-lang": "error",
+    "jsx-a11y/iframe-has-title": "error",
+    "jsx-a11y/img-redundant-alt": "error",
+    "jsx-a11y/interactive-supports-focus": "error",
+    "jsx-a11y/label-has-associated-control": [
+      "error",
+      {
+        "labelComponents": [],
+        "labelAttributes": [],
+        "controlComponents": [],
+        "assert": "both",
+        "depth": 25
+      }
     ],
-    "jsx-a11y/iframe-has-title": [
-      "error"
-    ],
-    "jsx-a11y/img-redundant-alt": [
-      "error"
-    ],
-    "jsx-a11y/interactive-supports-focus": [
-      "error"
-    ],
-    "jsx-a11y/lang": [
-      "error"
-    ],
+    "jsx-a11y/lang": "error",
     "jsx-a11y/media-has-caption": [
       "error",
       {
@@ -1161,12 +479,8 @@
         "track": []
       }
     ],
-    "jsx-a11y/mouse-events-have-key-events": [
-      "error"
-    ],
-    "jsx-a11y/no-access-key": [
-      "error"
-    ],
+    "jsx-a11y/mouse-events-have-key-events": "error",
+    "jsx-a11y/no-access-key": "error",
     "jsx-a11y/no-autofocus": [
       "error",
       {
@@ -1249,12 +563,7 @@
         ]
       }
     ],
-    "jsx-a11y/no-onchange": [
-      "off"
-    ],
-    "jsx-a11y/no-redundant-roles": [
-      "error"
-    ],
+    "jsx-a11y/no-redundant-roles": "error",
     "jsx-a11y/no-static-element-interactions": [
       "error",
       {
@@ -1268,751 +577,101 @@
         ]
       }
     ],
-    "jsx-a11y/role-has-required-aria-props": [
-      "error"
-    ],
-    "jsx-a11y/role-supports-aria-props": [
-      "error"
-    ],
-    "jsx-a11y/scope": [
-      "error"
-    ],
-    "jsx-a11y/tabindex-no-positive": [
-      "error"
-    ],
-    "jsx-a11y/label-has-for": [
-      "off",
-      {
-        "components": [],
-        "required": {
-          "every": [
-            "nesting",
-            "id"
-          ]
-        },
-        "allowChildren": false
-      }
-    ],
-    "no-underscore-dangle": [
-      "error",
-      {
-        "allow": [
-          "__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"
-        ],
-        "allowAfterThis": false,
-        "allowAfterSuper": false,
-        "enforceInMethodNames": true,
-        "allowAfterThisConstructor": false,
-        "allowFunctionParams": true,
-        "enforceInClassFields": false,
-        "allowInArrayDestructuring": true,
-        "allowInObjectDestructuring": true
-      }
-    ],
+    "jsx-a11y/role-has-required-aria-props": "error",
+    "jsx-a11y/role-supports-aria-props": "error",
+    "jsx-a11y/scope": "error",
+    "jsx-a11y/tabindex-no-positive": "error",
     "jsx-quotes": [
       "error",
       "prefer-double"
     ],
-    "class-methods-use-this": [
+    "key-spacing": [
       "error",
       {
-        "exceptMethods": [
-          "render",
-          "getInitialState",
-          "getDefaultProps",
-          "getChildContext",
-          "componentWillMount",
-          "UNSAFE_componentWillMount",
-          "componentDidMount",
-          "componentWillReceiveProps",
-          "UNSAFE_componentWillReceiveProps",
-          "shouldComponentUpdate",
-          "componentWillUpdate",
-          "UNSAFE_componentWillUpdate",
-          "componentDidUpdate",
-          "componentWillUnmount",
-          "componentDidCatch",
-          "getSnapshotBeforeUpdate"
-        ],
-        "enforceForClassFields": true
+        "beforeColon": false,
+        "afterColon": true
       }
     ],
-    "react/display-name": [
-      "off",
-      {
-        "ignoreTranspilerName": false
-      }
-    ],
-    "react/forbid-prop-types": [
+    "keyword-spacing": [
       "error",
       {
-        "forbid": [
-          "any",
-          "array",
-          "object"
-        ],
-        "checkContextTypes": true,
-        "checkChildContextTypes": true
+        "before": true,
+        "after": true
       }
     ],
-    "react/forbid-dom-props": [
-      "off",
-      {
-        "forbid": []
-      }
-    ],
-    "react/jsx-boolean-value": [
+    "linebreak-style": [
       "error",
-      "never",
-      {
-        "always": []
-      }
+      "windows"
     ],
-    "react/jsx-closing-bracket-location": [
-      "error",
-      "line-aligned"
-    ],
-    "react/jsx-closing-tag-location": [
-      "error"
-    ],
-    "react/jsx-curly-spacing": [
-      "error",
-      "never",
-      {
-        "allowMultiline": true
-      }
-    ],
-    "react/jsx-handler-names": [
-      "off",
-      {
-        "eventHandlerPrefix": "handle",
-        "eventHandlerPropPrefix": "on"
-      }
-    ],
-    "react/jsx-key": [
-      "off"
-    ],
-    "react/jsx-max-props-per-line": [
+    "lines-around-directive": [
       "error",
       {
-        "maximum": 1,
-        "when": "multiline"
+        "before": "always",
+        "after": "always"
       }
     ],
-    "react/jsx-no-bind": [
+    "lines-between-class-members": [
+      "error",
+      "always",
+      {
+        "exceptAfterSingleLine": true
+      }
+    ],
+    "max-classes-per-file": [
+      "error",
+      1
+    ],
+    "max-len": [
       "error",
       {
-        "ignoreRefs": true,
-        "allowArrowFunctions": true,
-        "allowFunctions": false,
-        "allowBind": false,
-        "ignoreDOMComponents": true
+        "code": 120,
+        "ignoreTrailingComments": true,
+        "ignoreComments": true,
+        "ignoreUrls": true,
+        "ignoreStrings": true,
+        "tabWidth": 1
       }
     ],
-    "react/jsx-no-duplicate-props": [
-      "error",
-      {
-        "ignoreCase": true
-      }
-    ],
-    "react/jsx-no-literals": [
-      "off",
-      {
-        "noStrings": true
-      }
-    ],
-    "react/jsx-no-undef": [
-      "error"
-    ],
-    "react/jsx-pascal-case": [
-      "error",
-      {
-        "allowAllCaps": true,
-        "ignore": []
-      }
-    ],
-    "react/sort-prop-types": [
-      "off",
-      {
-        "ignoreCase": true,
-        "callbacksLast": false,
-        "requiredFirst": false,
-        "sortShapeProp": true
-      }
-    ],
-    "react/jsx-sort-prop-types": [
-      "off"
-    ],
-    "react/jsx-sort-props": [
-      "off",
-      {
-        "ignoreCase": true,
-        "callbacksLast": false,
-        "shorthandFirst": false,
-        "shorthandLast": false,
-        "noSortAlphabetically": false,
-        "reservedFirst": true
-      }
-    ],
-    "react/jsx-sort-default-props": [
-      "off",
-      {
-        "ignoreCase": true
-      }
-    ],
-    "react/jsx-uses-react": [
-      "error"
-    ],
-    "react/jsx-uses-vars": [
-      "error"
-    ],
-    "react/no-danger": [
-      "warn"
-    ],
-    "react/no-deprecated": [
-      "error"
-    ],
-    "react/no-did-mount-set-state": [
-      "off"
-    ],
-    "react/no-did-update-set-state": [
-      "error"
-    ],
-    "react/no-will-update-set-state": [
-      "error"
-    ],
-    "react/no-direct-mutation-state": [
-      "off"
-    ],
-    "react/no-is-mounted": [
-      "error"
-    ],
-    "react/no-multi-comp": [
-      "off"
-    ],
-    "react/no-set-state": [
-      "off"
-    ],
-    "react/no-string-refs": [
-      "error"
-    ],
-    "react/no-unknown-property": [
-      "error"
-    ],
-    "react/prefer-es6-class": [
-      "error",
-      "always"
-    ],
-    "react/prefer-stateless-function": [
-      "error",
-      {
-        "ignorePureComponents": true
-      }
-    ],
-    "react/react-in-jsx-scope": [
-      "error"
-    ],
-    "react/require-render-return": [
-      "error"
-    ],
-    "react/self-closing-comp": [
-      "error"
-    ],
-    "react/sort-comp": [
-      "error",
-      {
-        "order": [
-          "static-variables",
-          "static-methods",
-          "instance-variables",
-          "lifecycle",
-          "/^handle.+$/",
-          "/^on.+$/",
-          "getters",
-          "setters",
-          "/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/",
-          "instance-methods",
-          "everything-else",
-          "rendering"
-        ],
-        "groups": {
-          "lifecycle": [
-            "displayName",
-            "propTypes",
-            "contextTypes",
-            "childContextTypes",
-            "mixins",
-            "statics",
-            "defaultProps",
-            "constructor",
-            "getDefaultProps",
-            "getInitialState",
-            "state",
-            "getChildContext",
-            "getDerivedStateFromProps",
-            "componentWillMount",
-            "UNSAFE_componentWillMount",
-            "componentDidMount",
-            "componentWillReceiveProps",
-            "UNSAFE_componentWillReceiveProps",
-            "shouldComponentUpdate",
-            "componentWillUpdate",
-            "UNSAFE_componentWillUpdate",
-            "getSnapshotBeforeUpdate",
-            "componentDidUpdate",
-            "componentDidCatch",
-            "componentWillUnmount"
-          ],
-          "rendering": [
-            "/^render.+$/",
-            "render"
-          ]
-        }
-      }
-    ],
-    "react/jsx-wrap-multilines": [
-      "error",
-      {
-        "declaration": "parens-new-line",
-        "assignment": "parens-new-line",
-        "return": "parens-new-line",
-        "arrow": "parens-new-line",
-        "condition": "parens-new-line",
-        "logical": "parens-new-line",
-        "prop": "parens-new-line"
-      }
-    ],
-    "react/jsx-first-prop-new-line": [
-      "error",
-      "multiline-multiprop"
-    ],
-    "react/jsx-equals-spacing": [
+    "multiline-ternary": [
       "error",
       "never"
     ],
-    "react/jsx-no-target-blank": [
+    "n/handle-callback-err": [
+      "error",
+      "^(err|error)$"
+    ],
+    "n/no-callback-literal": "error",
+    "n/no-deprecated-api": "error",
+    "n/no-exports-assign": "error",
+    "n/no-new-require": "error",
+    "n/no-path-concat": "error",
+    "n/process-exit-as-throw": "error",
+    "new-cap": [
       "error",
       {
-        "enforceDynamicLinks": "always",
-        "links": true,
-        "forms": false
+        "newIsCap": true,
+        "capIsNew": false,
+        "properties": true
       }
     ],
-    "react/jsx-no-comment-textnodes": [
-      "error"
-    ],
-    "react/no-render-return-value": [
-      "error"
-    ],
-    "react/require-optimization": [
-      "off",
-      {
-        "allowDecorators": []
-      }
-    ],
-    "react/no-find-dom-node": [
-      "error"
-    ],
-    "react/forbid-component-props": [
-      "off",
-      {
-        "forbid": []
-      }
-    ],
-    "react/forbid-elements": [
-      "off",
-      {
-        "forbid": []
-      }
-    ],
-    "react/no-danger-with-children": [
-      "error"
-    ],
-    "react/no-unused-prop-types": [
+    "new-parens": "error",
+    "newline-per-chained-call": [
       "error",
       {
-        "customValidators": [],
-        "skipShapeProps": true
+        "ignoreChainWithDepth": 4
       }
     ],
-    "react/style-prop-object": [
-      "error"
-    ],
-    "react/no-unescaped-entities": [
-      "error"
-    ],
-    "react/no-children-prop": [
-      "error"
-    ],
-    "react/jsx-tag-spacing": [
-      "error",
-      {
-        "closingSlash": "never",
-        "beforeSelfClosing": "always",
-        "afterOpening": "never",
-        "beforeClosing": "never"
-      }
-    ],
-    "react/jsx-space-before-closing": [
-      "off",
-      "always"
-    ],
-    "react/no-array-index-key": [
-      "error"
-    ],
-    "react/require-default-props": [
-      "error",
-      {
-        "forbidDefaultForRequired": true
-      }
-    ],
-    "react/forbid-foreign-prop-types": [
-      "warn",
-      {
-        "allowInPropTypes": true
-      }
-    ],
-    "react/void-dom-elements-no-children": [
-      "error"
-    ],
-    "react/default-props-match-prop-types": [
-      "error",
-      {
-        "allowRequiredDefaults": false
-      }
-    ],
-    "react/no-redundant-should-component-update": [
-      "error"
-    ],
-    "react/no-unused-state": [
-      "error"
-    ],
-    "react/boolean-prop-naming": [
-      "off",
-      {
-        "propTypeNames": [
-          "bool",
-          "mutuallyExclusiveTrueProps"
-        ],
-        "rule": "^(is|has)[A-Z]([A-Za-z0-9]?)+",
-        "message": ""
-      }
-    ],
-    "react/no-typos": [
-      "error"
-    ],
-    "react/jsx-curly-brace-presence": [
-      "error",
-      {
-        "props": "never",
-        "children": "never"
-      }
-    ],
-    "react/destructuring-assignment": [
-      "error",
-      "always"
-    ],
-    "react/no-access-state-in-setstate": [
-      "error"
-    ],
-    "react/button-has-type": [
-      "error",
-      {
-        "button": true,
-        "submit": true,
-        "reset": false
-      }
-    ],
-    "react/jsx-child-element-spacing": [
-      "off"
-    ],
-    "react/no-this-in-sfc": [
-      "error"
-    ],
-    "react/jsx-max-depth": [
-      "off"
-    ],
-    "react/jsx-props-no-multi-spaces": [
-      "error"
-    ],
-    "react/no-unsafe": [
-      "off"
-    ],
-    "react/jsx-fragments": [
-      "error",
-      "syntax"
-    ],
-    "react/jsx-curly-newline": [
-      "error",
-      {
-        "multiline": "consistent",
-        "singleline": "consistent"
-      }
-    ],
-    "react/state-in-constructor": [
-      "error",
-      "always"
-    ],
-    "react/static-property-placement": [
-      "error",
-      "property assignment"
-    ],
-    "react/jsx-props-no-spreading": [
-      "error",
-      {
-        "html": "enforce",
-        "custom": "enforce",
-        "explicitSpread": "ignore",
-        "exceptions": []
-      }
-    ],
-    "react/prefer-read-only-props": [
-      "off"
-    ],
-    "react/jsx-no-script-url": [
-      "error",
-      [
-        {
-          "name": "Link",
-          "props": [
-            "to"
-          ]
-        }
-      ]
-    ],
-    "react/no-adjacent-inline-elements": [
-      "off"
-    ],
-    "react/jsx-newline": [
-      "off"
-    ],
-    "react/jsx-no-constructed-context-values": [
-      "error"
-    ],
-    "react/no-unstable-nested-components": [
-      "error"
-    ],
-    "react/no-namespace": [
-      "error"
-    ],
-    "react/prefer-exact-props": [
-      "error"
-    ],
-    "react/no-arrow-function-lifecycle": [
-      "error"
-    ],
-    "react/no-invalid-html-attribute": [
-      "error"
-    ],
-    "react/no-unused-class-component-methods": [
-      "error"
-    ],
-    "strict": [
-      "error",
-      "never"
-    ],
-    "import/no-unresolved": [
-      "error",
-      {
-        "commonjs": true,
-        "caseSensitive": true,
-        "caseSensitiveStrict": false
-      }
-    ],
-    "import/named": [
-      "error"
-    ],
-    "import/default": [
-      "off"
-    ],
-    "import/namespace": [
-      "off"
-    ],
-    "import/no-named-as-default": [
-      "error"
-    ],
-    "import/no-named-as-default-member": [
-      "error"
-    ],
-    "import/no-deprecated": [
-      "off"
-    ],
-    "import/no-extraneous-dependencies": [
-      "error",
-      {
-        "devDependencies": [
-          "test/**",
-          "tests/**",
-          "spec/**",
-          "**/__tests__/**",
-          "**/__mocks__/**",
-          "test.{js,jsx}",
-          "test-*.{js,jsx}",
-          "**/*{.,_}{test,spec}.{js,jsx}",
-          "**/jest.config.js",
-          "**/jest.setup.js",
-          "**/vue.config.js",
-          "**/webpack.config.js",
-          "**/webpack.config.*.js",
-          "**/rollup.config.js",
-          "**/rollup.config.*.js",
-          "**/gulpfile.js",
-          "**/gulpfile.*.js",
-          "**/Gruntfile{,.js}",
-          "**/protractor.conf.js",
-          "**/protractor.conf.*.js",
-          "**/karma.conf.js",
-          "**/.eslintrc.js"
-        ],
-        "optionalDependencies": false
-      }
-    ],
-    "import/no-mutable-exports": [
-      "error"
-    ],
-    "import/no-commonjs": [
-      "off"
-    ],
-    "import/no-amd": [
-      "error"
-    ],
-    "import/no-nodejs-modules": [
-      "off"
-    ],
-    "import/imports-first": [
-      "off"
-    ],
-    "import/no-namespace": [
-      "off"
-    ],
-    "import/extensions": [
-      "error",
-      "ignorePackages",
-      {
-        "js": "never",
-        "mjs": "never",
-        "jsx": "never"
-      }
-    ],
-    "import/order": [
-      "error",
-      {
-        "groups": [
-          [
-            "builtin",
-            "external",
-            "internal"
-          ]
-        ],
-        "distinctGroup": true,
-        "warnOnUnassignedImports": false
-      }
-    ],
-    "import/newline-after-import": [
-      "error"
-    ],
-    "import/prefer-default-export": [
-      "error"
-    ],
-    "import/no-restricted-paths": [
-      "off"
-    ],
-    "import/max-dependencies": [
-      "off",
-      {
-        "max": 10
-      }
-    ],
-    "import/no-dynamic-require": [
-      "error"
-    ],
-    "import/no-internal-modules": [
-      "off",
-      {
-        "allow": []
-      }
-    ],
-    "import/unambiguous": [
-      "off"
-    ],
-    "import/no-unassigned-import": [
-      "off"
-    ],
-    "import/no-anonymous-default-export": [
-      "off",
-      {
-        "allowArray": false,
-        "allowArrowFunction": false,
-        "allowAnonymousClass": false,
-        "allowAnonymousFunction": false,
-        "allowLiteral": false,
-        "allowObject": false
-      }
-    ],
-    "import/exports-last": [
-      "off"
-    ],
-    "import/group-exports": [
-      "off"
-    ],
-    "import/no-default-export": [
-      "off"
-    ],
-    "import/no-named-export": [
-      "off"
-    ],
-    "import/no-self-import": [
-      "error"
-    ],
-    "import/no-cycle": [
-      "error",
-      {
-        "maxDepth": "∞",
-        "ignoreExternal": false,
-        "allowUnsafeDynamicCyclicDependency": false
-      }
-    ],
-    "import/no-useless-path-segments": [
-      "error",
-      {
-        "commonjs": true
-      }
-    ],
-    "import/dynamic-import-chunkname": [
-      "off",
-      {
-        "importFunctions": [],
-        "webpackChunknameFormat": "[0-9a-zA-Z-_/.]+"
-      }
-    ],
-    "import/no-relative-parent-imports": [
-      "off"
-    ],
-    "import/no-unused-modules": [
-      "off",
-      {
-        "ignoreExports": [],
-        "missingExports": true,
-        "unusedExports": true
-      }
-    ],
-    "import/no-import-module-exports": [
-      "error",
-      {
-        "exceptions": []
-      }
-    ],
-    "import/no-relative-packages": [
-      "error"
-    ],
-    "arrow-body-style": [
-      "error",
-      "as-needed",
-      {
-        "requireReturnForObjectLiteral": false
-      }
-    ],
-    "arrow-parens": [
+    "no-alert": "warn",
+    "no-array-constructor": "error",
+    "no-async-promise-executor": "error",
+    "no-await-in-loop": "error",
+    "no-bitwise": "error",
+    "no-buffer-constructor": "error",
+    "no-caller": "error",
+    "no-case-declarations": "error",
+    "no-class-assign": "error",
+    "no-compare-neg-zero": "error",
+    "no-cond-assign": [
       "error",
       "always"
     ],
@@ -2023,9 +682,167 @@
         "onlyOneSimpleParam": false
       }
     ],
-    "no-duplicate-imports": [
-      "off"
+    "no-console": "error",
+    "no-const-assign": "error",
+    "no-constant-condition": [
+      "error",
+      {
+        "checkLoops": false
+      }
     ],
+    "no-constructor-return": "error",
+    "no-continue": "error",
+    "no-control-regex": "error",
+    "no-debugger": "error",
+    "no-delete-var": "error",
+    "no-dupe-args": "error",
+    "no-dupe-class-members": "error",
+    "no-dupe-else-if": "error",
+    "no-dupe-keys": "error",
+    "no-duplicate-case": "error",
+    "no-else-return": [
+      "error",
+      {
+        "allowElseIf": false
+      }
+    ],
+    "no-empty": [
+      "error",
+      {
+        "allowEmptyCatch": true
+      }
+    ],
+    "no-empty-character-class": "error",
+    "no-empty-pattern": "error",
+    "no-eval": "error",
+    "no-ex-assign": "error",
+    "no-extend-native": "error",
+    "no-extra-bind": "error",
+    "no-extra-boolean-cast": "error",
+    "no-extra-label": "error",
+    "no-extra-parens": [
+      "error",
+      "functions"
+    ],
+    "no-extra-semi": "error",
+    "no-fallthrough": "error",
+    "no-floating-decimal": "error",
+    "no-func-assign": "error",
+    "no-global-assign": [
+      "error",
+      {
+        "exceptions": []
+      }
+    ],
+    "no-implied-eval": "error",
+    "no-import-assign": "error",
+    "no-inner-declarations": "error",
+    "no-invalid-regexp": "error",
+    "no-irregular-whitespace": "error",
+    "no-iterator": "error",
+    "no-label-var": "error",
+    "no-labels": [
+      "error",
+      {
+        "allowLoop": false,
+        "allowSwitch": false
+      }
+    ],
+    "no-lone-blocks": "error",
+    "no-lonely-if": "error",
+    "no-loop-func": "error",
+    "no-loss-of-precision": "error",
+    "no-misleading-character-class": "error",
+    "no-mixed-operators": [
+      "error",
+      {
+        "groups": [
+          [
+            "==",
+            "!=",
+            "===",
+            "!==",
+            ">",
+            ">=",
+            "<",
+            "<="
+          ],
+          [
+            "&&",
+            "||"
+          ],
+          [
+            "in",
+            "instanceof"
+          ]
+        ],
+        "allowSamePrecedence": true
+      }
+    ],
+    "no-mixed-spaces-and-tabs": "error",
+    "no-multi-assign": "error",
+    "no-multi-spaces": [
+      "error",
+      {
+        "ignoreEOLComments": false
+      }
+    ],
+    "no-multi-str": "error",
+    "no-multiple-empty-lines": [
+      "error",
+      {
+        "max": 1,
+        "maxBOF": 0,
+        "maxEOF": 0
+      }
+    ],
+    "no-nested-ternary": "error",
+    "no-new": "error",
+    "no-new-func": "error",
+    "no-new-object": "error",
+    "no-new-require": "error",
+    "no-new-symbol": "error",
+    "no-new-wrappers": "error",
+    "no-nonoctal-decimal-escape": "error",
+    "no-obj-calls": "error",
+    "no-octal": "error",
+    "no-octal-escape": "error",
+    "no-param-reassign": [
+      "error",
+      {
+        "props": true,
+        "ignorePropertyModificationsFor": [
+          "acc",
+          "accumulator",
+          "e",
+          "ctx",
+          "context",
+          "req",
+          "request",
+          "res",
+          "response",
+          "$scope",
+          "staticContext"
+        ]
+      }
+    ],
+    "no-path-concat": "error",
+    "no-plusplus": [
+      "error",
+      {
+        "allowForLoopAfterthoughts": true
+      }
+    ],
+    "no-promise-executor-return": "error",
+    "no-proto": "error",
+    "no-prototype-builtins": "error",
+    "no-redeclare": [
+      "error",
+      {
+        "builtinGlobals": false
+      }
+    ],
+    "no-regex-spaces": "error",
     "no-restricted-exports": [
       "error",
       {
@@ -2034,74 +851,6 @@
           "then"
         ]
       }
-    ],
-    "no-restricted-imports": [
-      "off",
-      {
-        "paths": [],
-        "patterns": []
-      }
-    ],
-    "prefer-arrow-callback": [
-      "error",
-      {
-        "allowNamedFunctions": false,
-        "allowUnboundThis": true
-      }
-    ],
-    "prefer-destructuring": [
-      "error",
-      {
-        "VariableDeclarator": {
-          "array": false,
-          "object": true
-        },
-        "AssignmentExpression": {
-          "array": true,
-          "object": false
-        }
-      },
-      {
-        "enforceForRenamedProperties": false
-      }
-    ],
-    "prefer-numeric-literals": [
-      "error"
-    ],
-    "prefer-reflect": [
-      "off"
-    ],
-    "prefer-rest-params": [
-      "error"
-    ],
-    "prefer-spread": [
-      "error"
-    ],
-    "prefer-template": [
-      "error"
-    ],
-    "sort-imports": [
-      "off",
-      {
-        "ignoreCase": false,
-        "ignoreDeclarationSort": false,
-        "ignoreMemberSort": false,
-        "memberSyntaxSortOrder": [
-          "none",
-          "all",
-          "multiple",
-          "single"
-        ]
-      }
-    ],
-    "init-declarations": [
-      "off"
-    ],
-    "no-catch-shadow": [
-      "off"
-    ],
-    "no-label-var": [
-      "error"
     ],
     "no-restricted-globals": [
       "error",
@@ -2172,399 +921,6 @@
       "toolbar",
       "top"
     ],
-    "no-shadow": [
-      "error"
-    ],
-    "no-undefined": [
-      "off"
-    ],
-    "array-bracket-newline": [
-      "off",
-      "consistent"
-    ],
-    "array-element-newline": [
-      "off",
-      {
-        "multiline": true,
-        "minItems": 3
-      }
-    ],
-    "capitalized-comments": [
-      "off",
-      "never",
-      {
-        "line": {
-          "ignorePattern": ".*",
-          "ignoreInlineComments": true,
-          "ignoreConsecutiveComments": true
-        },
-        "block": {
-          "ignorePattern": ".*",
-          "ignoreInlineComments": true,
-          "ignoreConsecutiveComments": true
-        }
-      }
-    ],
-    "consistent-this": [
-      "off"
-    ],
-    "function-call-argument-newline": [
-      "error",
-      "consistent"
-    ],
-    "func-name-matching": [
-      "off",
-      "always",
-      {
-        "includeCommonJSModuleExports": false,
-        "considerPropertyDescriptor": true
-      }
-    ],
-    "func-names": [
-      "warn"
-    ],
-    "func-style": [
-      "off",
-      "expression"
-    ],
-    "function-paren-newline": [
-      "error",
-      "multiline-arguments"
-    ],
-    "id-denylist": [
-      "off"
-    ],
-    "id-length": [
-      "off"
-    ],
-    "id-match": [
-      "off"
-    ],
-    "implicit-arrow-linebreak": [
-      "error",
-      "beside"
-    ],
-    "line-comment-position": [
-      "off",
-      {
-        "position": "above",
-        "ignorePattern": "",
-        "applyDefaultPatterns": true
-      }
-    ],
-    "lines-around-comment": [
-      "off"
-    ],
-    "lines-around-directive": [
-      "error",
-      {
-        "before": "always",
-        "after": "always"
-      }
-    ],
-    "max-depth": [
-      "off",
-      4
-    ],
-    "max-lines": [
-      "off",
-      {
-        "max": 300,
-        "skipBlankLines": true,
-        "skipComments": true
-      }
-    ],
-    "max-lines-per-function": [
-      "off",
-      {
-        "max": 50,
-        "skipBlankLines": true,
-        "skipComments": true,
-        "IIFEs": true
-      }
-    ],
-    "max-nested-callbacks": [
-      "off"
-    ],
-    "max-params": [
-      "off",
-      3
-    ],
-    "max-statements": [
-      "off",
-      10
-    ],
-    "max-statements-per-line": [
-      "off",
-      {
-        "max": 1
-      }
-    ],
-    "multiline-comment-style": [
-      "off",
-      "starred-block"
-    ],
-    "newline-after-var": [
-      "off"
-    ],
-    "newline-before-return": [
-      "off"
-    ],
-    "newline-per-chained-call": [
-      "error",
-      {
-        "ignoreChainWithDepth": 4
-      }
-    ],
-    "no-bitwise": [
-      "error"
-    ],
-    "no-continue": [
-      "error"
-    ],
-    "no-inline-comments": [
-      "off"
-    ],
-    "no-lonely-if": [
-      "error"
-    ],
-    "no-multi-assign": [
-      "error"
-    ],
-    "no-negated-condition": [
-      "off"
-    ],
-    "no-nested-ternary": [
-      "error"
-    ],
-    "no-restricted-syntax": [
-      "error",
-      {
-        "selector": "ForInStatement",
-        "message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
-      },
-      {
-        "selector": "ForOfStatement",
-        "message": "iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations."
-      },
-      {
-        "selector": "LabeledStatement",
-        "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand."
-      },
-      {
-        "selector": "WithStatement",
-        "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
-      }
-    ],
-    "no-spaced-func": [
-      "error"
-    ],
-    "no-ternary": [
-      "off"
-    ],
-    "nonblock-statement-body-position": [
-      "error",
-      "beside",
-      {
-        "overrides": {}
-      }
-    ],
-    "one-var-declaration-per-line": [
-      "error",
-      "always"
-    ],
-    "operator-assignment": [
-      "error",
-      "always"
-    ],
-    "padding-line-between-statements": [
-      "off"
-    ],
-    "prefer-exponentiation-operator": [
-      "error"
-    ],
-    "prefer-object-spread": [
-      "error"
-    ],
-    "require-jsdoc": [
-      "off"
-    ],
-    "semi-style": [
-      "error",
-      "last"
-    ],
-    "sort-keys": [
-      "off",
-      "asc",
-      {
-        "caseSensitive": false,
-        "natural": true
-      }
-    ],
-    "sort-vars": [
-      "off"
-    ],
-    "switch-colon-spacing": [
-      "error",
-      {
-        "after": true,
-        "before": false
-      }
-    ],
-    "wrap-regex": [
-      "off"
-    ],
-    "callback-return": [
-      "off"
-    ],
-    "global-require": [
-      "error"
-    ],
-    "handle-callback-err": [
-      "off"
-    ],
-    "no-buffer-constructor": [
-      "error"
-    ],
-    "no-mixed-requires": [
-      "off",
-      false
-    ],
-    "no-new-require": [
-      "error"
-    ],
-    "no-path-concat": [
-      "error"
-    ],
-    "no-process-env": [
-      "off"
-    ],
-    "no-process-exit": [
-      "off"
-    ],
-    "no-restricted-modules": [
-      "off"
-    ],
-    "no-sync": [
-      "off"
-    ],
-    "no-await-in-loop": [
-      "error"
-    ],
-    "no-promise-executor-return": [
-      "error"
-    ],
-    "no-unused-private-class-members": [
-      "off"
-    ],
-    "no-negated-in-lhs": [
-      "off"
-    ],
-    "require-atomic-updates": [
-      "off"
-    ],
-    "valid-jsdoc": [
-      "off"
-    ],
-    "block-scoped-var": [
-      "error"
-    ],
-    "complexity": [
-      "off",
-      20
-    ],
-    "consistent-return": [
-      "error"
-    ],
-    "default-case": [
-      "error",
-      {
-        "commentPattern": "^no default$"
-      }
-    ],
-    "default-param-last": [
-      "error"
-    ],
-    "grouped-accessor-pairs": [
-      "error"
-    ],
-    "guard-for-in": [
-      "error"
-    ],
-    "max-classes-per-file": [
-      "error",
-      1
-    ],
-    "no-alert": [
-      "warn"
-    ],
-    "no-constructor-return": [
-      "error"
-    ],
-    "no-div-regex": [
-      "off"
-    ],
-    "no-else-return": [
-      "error",
-      {
-        "allowElseIf": false
-      }
-    ],
-    "no-eq-null": [
-      "off"
-    ],
-    "no-extra-label": [
-      "error"
-    ],
-    "no-native-reassign": [
-      "off"
-    ],
-    "no-implicit-coercion": [
-      "off",
-      {
-        "boolean": false,
-        "number": true,
-        "string": true,
-        "allow": []
-      }
-    ],
-    "no-implicit-globals": [
-      "off"
-    ],
-    "no-invalid-this": [
-      "off"
-    ],
-    "no-loop-func": [
-      "error"
-    ],
-    "no-magic-numbers": [
-      "off",
-      {
-        "ignore": [],
-        "ignoreArrayIndexes": true,
-        "enforceConst": true,
-        "detectObjects": false
-      }
-    ],
-    "no-param-reassign": [
-      "error",
-      {
-        "props": true,
-        "ignorePropertyModificationsFor": [
-          "acc",
-          "accumulator",
-          "e",
-          "ctx",
-          "context",
-          "req",
-          "request",
-          "res",
-          "response",
-          "$scope",
-          "staticContext"
-        ]
-      }
-    ],
     "no-restricted-properties": [
       "error",
       {
@@ -2616,40 +972,689 @@
         "message": "Use the exponentiation operator (**) instead."
       }
     ],
-    "no-return-await": [
-      "error"
-    ],
-    "no-script-url": [
-      "error"
-    ],
-    "no-useless-concat": [
-      "error"
-    ],
-    "no-warning-comments": [
-      "off",
+    "no-restricted-syntax": [
+      "error",
       {
-        "terms": [
-          "todo",
-          "fixme",
-          "xxx"
-        ],
-        "location": "start"
+        "selector": "ForInStatement",
+        "message": "for..in loops iterate over the entire prototype chain, which is virtually never what you want. Use Object.{keys,values,entries}, and iterate over the resulting array."
+      },
+      {
+        "selector": "ForOfStatement",
+        "message": "iterators/generators require regenerator-runtime, which is too heavyweight for this guide to allow them. Separately, loops should be avoided in favor of array iterations."
+      },
+      {
+        "selector": "LabeledStatement",
+        "message": "Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand."
+      },
+      {
+        "selector": "WithStatement",
+        "message": "`with` is disallowed in strict mode because it makes code impossible to predict and optimize."
       }
     ],
-    "prefer-named-capture-group": [
-      "off"
+    "no-return-assign": [
+      "error",
+      "except-parens"
     ],
-    "radix": [
-      "error"
+    "no-return-await": "error",
+    "no-script-url": "error",
+    "no-self-assign": [
+      "error",
+      {
+        "props": true
+      }
     ],
-    "require-await": [
-      "off"
+    "no-self-compare": "error",
+    "no-sequences": "error",
+    "no-setter-return": "error",
+    "no-shadow": "error",
+    "no-shadow-restricted-names": "error",
+    "no-spaced-func": "error",
+    "no-sparse-arrays": "error",
+    "no-template-curly-in-string": "error",
+    "no-this-before-super": "error",
+    "no-throw-literal": "error",
+    "no-trailing-spaces": [
+      "error",
+      {
+        "skipBlankLines": false,
+        "ignoreComments": false
+      }
     ],
-    "require-unicode-regexp": [
-      "off"
+    "no-undef": "error",
+    "no-undef-init": "error",
+    "no-underscore-dangle": [
+      "error",
+      {
+        "allow": [
+          "__REDUX_DEVTOOLS_EXTENSION_COMPOSE__"
+        ],
+        "allowAfterThis": false,
+        "allowAfterSuper": false,
+        "enforceInMethodNames": true,
+        "allowAfterThisConstructor": false,
+        "allowFunctionParams": true,
+        "enforceInClassFields": false,
+        "allowInArrayDestructuring": true,
+        "allowInObjectDestructuring": true
+      }
     ],
-    "vars-on-top": [
-      "error"
+    "no-unexpected-multiline": "error",
+    "no-unmodified-loop-condition": "error",
+    "no-unneeded-ternary": [
+      "error",
+      {
+        "defaultAssignment": false
+      }
+    ],
+    "no-unreachable": "error",
+    "no-unreachable-loop": [
+      "error",
+      {
+        "ignore": []
+      }
+    ],
+    "no-unsafe-finally": "error",
+    "no-unsafe-negation": "error",
+    "no-unsafe-optional-chaining": [
+      "error",
+      {
+        "disallowArithmeticOperators": true
+      }
+    ],
+    "no-unused-expressions": [
+      "error",
+      {
+        "allowShortCircuit": true,
+        "allowTernary": true,
+        "allowTaggedTemplates": true,
+        "enforceForJSX": false
+      }
+    ],
+    "no-unused-labels": "error",
+    "no-unused-vars": [
+      "error",
+      {
+        "args": "none",
+        "caughtErrors": "none",
+        "ignoreRestSiblings": true,
+        "vars": "all"
+      }
+    ],
+    "no-use-before-define": [
+      "error",
+      {
+        "functions": false,
+        "classes": false,
+        "variables": false
+      }
+    ],
+    "no-useless-backreference": "error",
+    "no-useless-call": "error",
+    "no-useless-catch": "error",
+    "no-useless-computed-key": "error",
+    "no-useless-concat": "error",
+    "no-useless-constructor": "error",
+    "no-useless-escape": "error",
+    "no-useless-rename": [
+      "error",
+      {
+        "ignoreDestructuring": false,
+        "ignoreImport": false,
+        "ignoreExport": false
+      }
+    ],
+    "no-useless-return": "error",
+    "no-var": "warn",
+    "no-void": "error",
+    "no-whitespace-before-property": "error",
+    "no-with": "error",
+    "nonblock-statement-body-position": [
+      "error",
+      "beside",
+      {
+        "overrides": {}
+      }
+    ],
+    "object-curly-newline": [
+      "error",
+      {
+        "multiline": true,
+        "consistent": true
+      }
+    ],
+    "object-curly-spacing": [
+      "error",
+      "always"
+    ],
+    "object-property-newline": [
+      "error",
+      {
+        "allowMultiplePropertiesPerLine": true,
+        "allowAllPropertiesOnSameLine": false
+      }
+    ],
+    "object-shorthand": [
+      "warn",
+      "properties"
+    ],
+    "one-var": [
+      "error",
+      {
+        "initialized": "never"
+      }
+    ],
+    "one-var-declaration-per-line": [
+      "error",
+      "always"
+    ],
+    "operator-assignment": [
+      "error",
+      "always"
+    ],
+    "operator-linebreak": [
+      "error",
+      "after",
+      {
+        "overrides": {
+          "?": "before",
+          ":": "before",
+          "|>": "before"
+        }
+      }
+    ],
+    "padded-blocks": [
+      "error",
+      {
+        "blocks": "never",
+        "switches": "never",
+        "classes": "never"
+      }
+    ],
+    "prefer-arrow-callback": [
+      "error",
+      {
+        "allowNamedFunctions": false,
+        "allowUnboundThis": true
+      }
+    ],
+    "prefer-const": [
+      "error",
+      {
+        "destructuring": "all",
+        "ignoreReadBeforeAssign": false
+      }
+    ],
+    "prefer-destructuring": [
+      "error",
+      {
+        "VariableDeclarator": {
+          "array": false,
+          "object": true
+        },
+        "AssignmentExpression": {
+          "array": true,
+          "object": false
+        }
+      },
+      {
+        "enforceForRenamedProperties": false
+      }
+    ],
+    "prefer-exponentiation-operator": "error",
+    "prefer-numeric-literals": "error",
+    "prefer-object-spread": "error",
+    "prefer-promise-reject-errors": [
+      "error",
+      {
+        "allowEmptyReject": true
+      }
+    ],
+    "prefer-regex-literals": [
+      "error",
+      {
+        "disallowRedundantWrapping": true
+      }
+    ],
+    "prefer-rest-params": "error",
+    "prefer-spread": "error",
+    "prefer-template": "error",
+    "promise/param-names": "error",
+    "quote-props": [
+      "error",
+      "as-needed"
+    ],
+    "quotes": [
+      "error",
+      "single",
+      {
+        "avoidEscape": true,
+        "allowTemplateLiterals": false
+      }
+    ],
+    "radix": "error",
+    "react-hooks/exhaustive-deps": "error",
+    "react-hooks/rules-of-hooks": "error",
+    "react/button-has-type": [
+      "error",
+      {
+        "button": true,
+        "submit": true,
+        "reset": false
+      }
+    ],
+    "react/default-props-match-prop-types": [
+      "error",
+      {
+        "allowRequiredDefaults": false
+      }
+    ],
+    "react/destructuring-assignment": [
+      "error",
+      "always"
+    ],
+    "react/forbid-foreign-prop-types": [
+      "warn",
+      {
+        "allowInPropTypes": true
+      }
+    ],
+    "react/forbid-prop-types": [
+      "error",
+      {
+        "forbid": [
+          "any",
+          "array",
+          "object"
+        ],
+        "checkContextTypes": true,
+        "checkChildContextTypes": true
+      }
+    ],
+    "react/function-component-definition": [
+      "error",
+      {
+        "namedComponents": "arrow-function",
+        "unnamedComponents": "arrow-function"
+      }
+    ],
+    "react/jsx-boolean-value": [
+      "error",
+      "never",
+      {
+        "always": []
+      }
+    ],
+    "react/jsx-closing-bracket-location": [
+      "error",
+      "line-aligned"
+    ],
+    "react/jsx-closing-tag-location": "error",
+    "react/jsx-curly-brace-presence": [
+      "error",
+      {
+        "props": "never",
+        "children": "never"
+      }
+    ],
+    "react/jsx-curly-newline": [
+      "error",
+      {
+        "multiline": "consistent",
+        "singleline": "consistent"
+      }
+    ],
+    "react/jsx-curly-spacing": [
+      "error",
+      "never",
+      {
+        "allowMultiline": true
+      }
+    ],
+    "react/jsx-equals-spacing": [
+      "error",
+      "never"
+    ],
+    "react/jsx-filename-extension": [
+      "warn",
+      {
+        "allow": "as-needed"
+      }
+    ],
+    "react/jsx-first-prop-new-line": [
+      "error",
+      "multiline-multiprop"
+    ],
+    "react/jsx-fragments": [
+      "error",
+      "syntax"
+    ],
+    "react/jsx-indent": [
+      "error",
+      "tab"
+    ],
+    "react/jsx-indent-props": [
+      "error",
+      "tab"
+    ],
+    "react/jsx-max-props-per-line": [
+      "error",
+      {
+        "maximum": 1,
+        "when": "multiline"
+      }
+    ],
+    "react/jsx-no-bind": [
+      "error",
+      {
+        "ignoreRefs": true,
+        "allowArrowFunctions": true,
+        "allowFunctions": false,
+        "allowBind": false,
+        "ignoreDOMComponents": true
+      }
+    ],
+    "react/jsx-no-comment-textnodes": "error",
+    "react/jsx-no-constructed-context-values": "error",
+    "react/jsx-no-duplicate-props": [
+      "error",
+      {
+        "ignoreCase": true
+      }
+    ],
+    "react/jsx-no-script-url": [
+      "error",
+      [
+        {
+          "name": "Link",
+          "props": [
+            "to"
+          ]
+        }
+      ]
+    ],
+    "react/jsx-no-target-blank": [
+      "error",
+      {
+        "enforceDynamicLinks": "always",
+        "links": true,
+        "forms": false
+      }
+    ],
+    "react/jsx-no-undef": "error",
+    "react/jsx-no-useless-fragment": "error",
+    "react/jsx-pascal-case": [
+      "error",
+      {
+        "allowAllCaps": true,
+        "ignore": []
+      }
+    ],
+    "react/jsx-props-no-multi-spaces": "error",
+    "react/jsx-props-no-spreading": [
+      "error",
+      {
+        "html": "enforce",
+        "custom": "enforce",
+        "explicitSpread": "ignore",
+        "exceptions": []
+      }
+    ],
+    "react/jsx-tag-spacing": [
+      "error",
+      {
+        "closingSlash": "never",
+        "beforeSelfClosing": "always",
+        "afterOpening": "never",
+        "beforeClosing": "never"
+      }
+    ],
+    "react/jsx-uses-react": "error",
+    "react/jsx-uses-vars": "error",
+    "react/jsx-wrap-multilines": [
+      "error",
+      {
+        "declaration": "parens-new-line",
+        "assignment": "parens-new-line",
+        "return": "parens-new-line",
+        "arrow": "parens-new-line",
+        "condition": "parens-new-line",
+        "logical": "parens-new-line",
+        "prop": "parens-new-line"
+      }
+    ],
+    "react/no-access-state-in-setstate": "error",
+    "react/no-array-index-key": "error",
+    "react/no-arrow-function-lifecycle": "error",
+    "react/no-children-prop": "error",
+    "react/no-danger": "warn",
+    "react/no-danger-with-children": "error",
+    "react/no-deprecated": "error",
+    "react/no-did-update-set-state": "error",
+    "react/no-find-dom-node": "error",
+    "react/no-invalid-html-attribute": "error",
+    "react/no-is-mounted": "error",
+    "react/no-namespace": "error",
+    "react/no-redundant-should-component-update": "error",
+    "react/no-render-return-value": "error",
+    "react/no-string-refs": "error",
+    "react/no-this-in-sfc": "error",
+    "react/no-typos": "error",
+    "react/no-unescaped-entities": "error",
+    "react/no-unknown-property": "error",
+    "react/no-unstable-nested-components": "error",
+    "react/no-unused-class-component-methods": "error",
+    "react/no-unused-prop-types": [
+      "error",
+      {
+        "customValidators": [],
+        "skipShapeProps": true
+      }
+    ],
+    "react/no-unused-state": "error",
+    "react/no-will-update-set-state": "error",
+    "react/prefer-es6-class": [
+      "error",
+      "always"
+    ],
+    "react/prefer-exact-props": "error",
+    "react/prefer-stateless-function": [
+      "error",
+      {
+        "ignorePureComponents": true
+      }
+    ],
+    "react/react-in-jsx-scope": "error",
+    "react/require-default-props": [
+      "error",
+      {
+        "forbidDefaultForRequired": true
+      }
+    ],
+    "react/require-render-return": "error",
+    "react/self-closing-comp": "error",
+    "react/sort-comp": [
+      "error",
+      {
+        "order": [
+          "static-variables",
+          "static-methods",
+          "instance-variables",
+          "lifecycle",
+          "/^handle.+$/",
+          "/^on.+$/",
+          "getters",
+          "setters",
+          "/^(get|set)(?!(InitialState$|DefaultProps$|ChildContext$)).+$/",
+          "instance-methods",
+          "everything-else",
+          "rendering"
+        ],
+        "groups": {
+          "lifecycle": [
+            "displayName",
+            "propTypes",
+            "contextTypes",
+            "childContextTypes",
+            "mixins",
+            "statics",
+            "defaultProps",
+            "constructor",
+            "getDefaultProps",
+            "getInitialState",
+            "state",
+            "getChildContext",
+            "getDerivedStateFromProps",
+            "componentWillMount",
+            "UNSAFE_componentWillMount",
+            "componentDidMount",
+            "componentWillReceiveProps",
+            "UNSAFE_componentWillReceiveProps",
+            "shouldComponentUpdate",
+            "componentWillUpdate",
+            "UNSAFE_componentWillUpdate",
+            "getSnapshotBeforeUpdate",
+            "componentDidUpdate",
+            "componentDidCatch",
+            "componentWillUnmount"
+          ],
+          "rendering": [
+            "/^render.+$/",
+            "render"
+          ]
+        }
+      }
+    ],
+    "react/state-in-constructor": [
+      "error",
+      "always"
+    ],
+    "react/static-property-placement": [
+      "error",
+      "property assignment"
+    ],
+    "react/style-prop-object": "error",
+    "react/void-dom-elements-no-children": "error",
+    "require-yield": "error",
+    "rest-spread-spacing": [
+      "error",
+      "never"
+    ],
+    "semi": [
+      "error",
+      "always"
+    ],
+    "semi-spacing": [
+      "error",
+      {
+        "before": false,
+        "after": true
+      }
+    ],
+    "semi-style": [
+      "error",
+      "last"
+    ],
+    "space-before-blocks": [
+      "error",
+      "always"
+    ],
+    "space-before-function-paren": [
+      "error",
+      "never"
+    ],
+    "space-in-parens": [
+      "error",
+      "never"
+    ],
+    "space-infix-ops": "error",
+    "space-unary-ops": [
+      "error",
+      {
+        "words": true,
+        "nonwords": false
+      }
+    ],
+    "spaced-comment": [
+      "error",
+      "always",
+      {
+        "line": {
+          "markers": [
+            "*package",
+            "!",
+            "/",
+            ",",
+            "="
+          ]
+        },
+        "block": {
+          "balanced": true,
+          "markers": [
+            "*package",
+            "!",
+            ",",
+            ":",
+            "::",
+            "flow-include"
+          ],
+          "exceptions": [
+            "*"
+          ]
+        }
+      }
+    ],
+    "strict": [
+      "error",
+      "never"
+    ],
+    "switch-colon-spacing": [
+      "error",
+      {
+        "after": true,
+        "before": false
+      }
+    ],
+    "symbol-description": "error",
+    "template-curly-spacing": [
+      "error",
+      "never"
+    ],
+    "template-tag-spacing": [
+      "error",
+      "never"
+    ],
+    "unicode-bom": [
+      "error",
+      "never"
+    ],
+    "use-isnan": [
+      "error",
+      {
+        "enforceForSwitchCase": true,
+        "enforceForIndexOf": true
+      }
+    ],
+    "valid-typeof": [
+      "error",
+      {
+        "requireStringLiterals": true
+      }
+    ],
+    "vars-on-top": "error",
+    "wrap-iife": [
+      "error",
+      "any",
+      {
+        "functionPrototypeMethods": true
+      }
+    ],
+    "yield-star-spacing": [
+      "error",
+      "both"
+    ],
+    "yoda": [
+      "error",
+      "never"
     ]
   },
   "settings": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "eslint": "eslint --ext .jsx,.js,.tsx,.ts .",
     "eslint-fix": "eslint --ext .jsx,.js,.tsx,.ts --fix .",
     "show-config": "node show-config.js",
-    "show-config:json": "node show-config.js --json"
+    "show-config:json": "node show-config.js --json",
+    "show-config:normalize": "node show-config.js --normalize"
   },
   "repository": {
     "type": "git",

--- a/show-config.js
+++ b/show-config.js
@@ -4,9 +4,16 @@
  * Prints the fully resolved ESLint configuration.
  *
  * Usage:
- *   node show-config.js              # pretty-print to stdout
- *   node show-config.js --json       # raw JSON to stdout
- *   node show-config.js [file]       # resolve config for a specific file
+ *   node show-config.js                        # pretty-print to stdout
+ *   node show-config.js --json                 # raw JSON to stdout
+ *   node show-config.js --json --normalize     # normalized JSON (for diffing)
+ *   node show-config.js [file]                 # resolve config for a specific file
+ *
+ * Flags:
+ *   --json         Output raw JSON instead of pretty-print
+ *   --normalize    Normalize severities to strings ("off"/"warn"/"error"),
+ *                  sort rules alphabetically, and strip "off" rules.
+ *                  Use this when comparing configs across setups.
  *
  * If no file is given, resolves the config as it would apply to a .js file
  * in the project root (the file does not need to exist).
@@ -16,15 +23,44 @@ const { ESLint } = require('eslint');
 const path = require('path');
 
 const args = process.argv.slice(2);
+const flags = ['--json', '--normalize'];
 const jsonFlag = args.includes('--json');
-const filePath = args.find((a) => a !== '--json') || 'file.js';
+const normalizeFlag = args.includes('--normalize');
+const filePath = args.find((a) => !flags.includes(a)) || 'file.js';
 const resolvedPath = path.resolve(filePath);
+
+const SEVERITY_MAP = { 0: 'off', 1: 'warn', 2: 'error' };
+
+function normalizeSeverity(value) {
+	if (Array.isArray(value)) {
+		const [sev, ...opts] = value;
+		const normalized = SEVERITY_MAP[sev] || sev;
+		return opts.length ? [normalized, ...opts] : normalized;
+	}
+	return SEVERITY_MAP[value] || value;
+}
+
+function normalizeRules(rules) {
+	const sorted = {};
+	const keys = Object.keys(rules).sort();
+	for (const key of keys) {
+		const normalized = normalizeSeverity(rules[key]);
+		const sev = Array.isArray(normalized) ? normalized[0] : normalized;
+		if (sev === 'off') continue;
+		sorted[key] = normalized;
+	}
+	return sorted;
+}
 
 (async () => {
 	const eslint = new ESLint();
 	const config = await eslint.calculateConfigForFile(resolvedPath);
 
-	if (jsonFlag) {
+	if (normalizeFlag) {
+		config.rules = normalizeRules(config.rules);
+	}
+
+	if (jsonFlag || normalizeFlag) {
 		process.stdout.write(JSON.stringify(config, null, 2));
 		process.stdout.write('\n');
 		return;


### PR DESCRIPTION
## Summary
- Add `--normalize` flag to `show-config.js` that standardizes severities to strings (`"off"`/`"warn"`/`"error"`), sorts rules alphabetically, and strips `"off"` rules — so two configs from different setups produce a clean diff
- Add `show-config:normalize` npm script
- Regenerate `eslint-config-old.json` with normalization applied

## Usage
```bash
npm run show-config:normalize    # normalized JSON for diffing

# Compare two setups:
npm run show-config:normalize > config-a.json   # on setup A
npm run show-config:normalize > config-b.json   # on setup B
diff config-a.json config-b.json
```

## Test plan
- [ ] Run `npm run show-config:normalize` and verify severities are strings and no "off" rules appear
- [ ] Compare normalized output from two different setups and confirm a clean diff

https://claude.ai/code/session_01RhSubqXL35cwBRiyDZRWww